### PR TITLE
test front matter parsing for @quick-links

### DIFF
--- a/_i18n/en/resources/moneropedia/merge-mining.md
+++ b/_i18n/en/resources/moneropedia/merge-mining.md
@@ -1,6 +1,10 @@
 ---
 entry: "Merge Mining"
-terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+terms:
+  - "merge-mine"
+  - "merge-mining"
+  - "something-works"
+  - "merge-mined"
 summary: "The process of mining two or more blockchains at the same time"
 ---
 

--- a/_i18n/en/resources/moneropedia/p2pool.md
+++ b/_i18n/en/resources/moneropedia/p2pool.md
@@ -10,7 +10,7 @@ summary: "Peer to peer mining pool for Monero"
 
 Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @something-works with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 


### PR DESCRIPTION
Merge-mining page showing the front matter included in html:
- [https://deploy-preview[...]/merge-mining](https://deploy-preview-15--effulgent-bombolone-f6cfb4.netlify.app/resources/moneropedia/merge-mining)

p2pool page using one of the terms (ctrl+f for "@something-works") correctly (the text is parsed and replaced with the correct hyperlink to the above merge mining guide)
- [https://deploy-preview[...]/p2pool](https://deploy-preview-15--effulgent-bombolone-f6cfb4.netlify.app/resources/moneropedia/p2pool)

a yaml lint says the front matter is valid, but my text editor disagrees


